### PR TITLE
Add helper for audio transcript outputs

### DIFF
--- a/src/video_transcription/pipeline.py
+++ b/src/video_transcription/pipeline.py
@@ -256,15 +256,116 @@ class VideoTranscriptionPipeline:
             num_speakers=self.num_speakers,
             method=self.speaker_method
         )
-        
+
         # Use same output generation logic as process_video
         return self._generate_outputs(
-            speaker_result, 
-            whisper_result, 
-            audio_path, 
-            output_dir, 
-            output_formats
+            speaker_result,
+            whisper_result,
+            audio_path,
+            output_dir,
+            output_formats,
         )
+
+    def _generate_outputs(
+        self,
+        speaker_result: Dict,
+        whisper_result: Dict,
+        audio_path: Union[str, Path],
+        output_dir: Optional[Union[str, Path]] = None,
+        output_formats: Optional[List[str]] = None,
+    ) -> Dict:
+        """Generate output files and summary information.
+
+        This helper is shared by ``process_video`` and ``process_audio``
+        to avoid duplicating the logic for creating transcript files and
+        assembling the result dictionary.
+
+        Args:
+            speaker_result: Speaker identification output.
+            whisper_result: Raw Whisper transcription result.
+            audio_path: Path to the processed audio file.
+            output_dir: Directory to write output files to.
+            output_formats: List of desired output formats.
+
+        Returns:
+            Dictionary containing processing results and output file paths.
+        """
+
+        audio_path = Path(audio_path)
+        if output_dir is None:
+            output_dir = audio_path.parent / "transcripts"
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        if output_formats is None:
+            output_formats = ["txt", "json"]
+
+        output_files: Dict[str, str] = {}
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        base_name = f"{audio_path.stem}_transcript_{timestamp}"
+
+        for format_type in output_formats:
+            if format_type == "txt":
+                txt_path = output_dir / f"{base_name}.txt"
+                self.formatter.save_transcript(
+                    speaker_result,
+                    txt_path,
+                    speaker_names=self.speaker_names,
+                    format_style="readable",
+                )
+                output_files["txt"] = str(txt_path)
+
+            elif format_type == "json":
+                json_path = output_dir / f"{base_name}.json"
+                export_data = {
+                    "audio_path": str(audio_path),
+                    "whisper_result": whisper_result,
+                    "speaker_result": speaker_result,
+                    "speaker_names": self.speaker_names,
+                    "pipeline_config": {
+                        "whisper_model": self.whisper_model,
+                        "device": self.transcriber.device,
+                        "speaker_method": speaker_result.get("method"),
+                        "num_speakers": self.num_speakers,
+                    },
+                    "processing_metadata": {
+                        "timestamp": timestamp,
+                        "pipeline_version": "1.0.0",
+                    },
+                }
+
+                with open(json_path, "w", encoding="utf-8") as f:
+                    json.dump(export_data, f, indent=2, ensure_ascii=False)
+                output_files["json"] = str(json_path)
+
+            elif format_type == "srt":
+                srt_path = output_dir / f"{base_name}.srt"
+                self.formatter.save_srt(
+                    speaker_result, srt_path, speaker_names=self.speaker_names
+                )
+                output_files["srt"] = str(srt_path)
+
+        segments = speaker_result.get("segments", [])
+        total_duration = segments[-1]["end"] if segments else 0
+
+        return {
+            "success": True,
+            "audio_path": str(audio_path),
+            "output_files": output_files,
+            "summary": {
+                "duration_minutes": total_duration / 60,
+                "num_segments": len(segments),
+                "num_speakers": speaker_result.get("num_speakers", 0),
+                "method": speaker_result.get("method", "unknown"),
+                "accuracy": speaker_result.get("accuracy_score", 0),
+                "confidence": speaker_result.get("confidence", "unknown"),
+                "processing_time": speaker_result.get("processing_time", 0),
+            },
+            "speaker_stats": self.formatter._calculate_speaker_stats(
+                speaker_result
+            ),
+        }
     
     def get_info(self) -> Dict:
         """

--- a/tests/test_video_transcription.py
+++ b/tests/test_video_transcription.py
@@ -220,6 +220,40 @@ class TestVideoTranscriptionPipeline:
         assert "transcriber" in info["components"]
         assert "speaker_identifier" in info["components"]
 
+    def test_process_audio_generates_outputs(self, tmp_path, monkeypatch):
+        """Test that processing an audio file generates transcript outputs."""
+        pipeline = VideoTranscriptionPipeline()
+
+        # Create dummy audio file
+        audio_file = tmp_path / "sample.wav"
+        audio_file.touch()
+
+        # Mock transcription and speaker identification
+        fake_whisper = {"segments": [{"start": 0.0, "end": 1.0, "text": "hi"}]}
+        fake_speaker = {
+            "segments": [{"start": 0.0, "end": 1.0, "text": "hi", "speaker": "A"}],
+            "num_speakers": 1,
+            "method": "audio_clustering",
+            "accuracy_score": 70,
+            "processing_time": 0.1,
+            "confidence": "medium",
+        }
+
+        monkeypatch.setattr(pipeline.transcriber, "transcribe", lambda path: fake_whisper)
+
+        def fake_identify(audio_path, whisper_result, num_speakers=None, method=None):
+            return fake_speaker
+
+        monkeypatch.setattr(
+            pipeline.speaker_identifier, "identify_speakers", fake_identify
+        )
+
+        result = pipeline.process_audio(str(audio_file), output_dir=tmp_path)
+
+        assert result["success"] is True
+        assert Path(result["output_files"]["txt"]).exists()
+        assert Path(result["output_files"]["json"]).exists()
+
 
 class TestBatchProcessor:
     """Test cases for BatchProcessor class."""


### PR DESCRIPTION
## Summary
- implement `_generate_outputs` helper in pipeline to create transcript files
- ensure `process_audio` uses shared output generation
- add regression test for audio processing outputs

## Testing
- `pytest --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_688d82fff6b4832fa48ad0cc76e31def